### PR TITLE
Untestet: Fix for parameter replacing

### DIFF
--- a/SqlSanitizer.Api/Controllers/FormatController.cs
+++ b/SqlSanitizer.Api/Controllers/FormatController.cs
@@ -28,6 +28,10 @@ namespace SqlSanitizer.Api.Controllers
                 formattedSqlQuery = formattedSqlQuery.Replace(charToRemove, "");
             }
 
+            // Order the parameters by the character length of the parameter names (to get the parameters with the longest names first), 
+            // to avoid replacing the parameter value for '@column10' with the value for '@column1' (as an example).
+            Array.Sort(request.Parameter, (x, y) => y.Name.Length.CompareTo(x.Name.Length));
+
             foreach (var parameter in request.Parameter)
             {
                 if (string.IsNullOrWhiteSpace(parameter.Value))


### PR DESCRIPTION
added Array.Sort before the parameter replacing, to avoid to avoid replacing the parameter value for '@column10' with the value for '@column1' (as an example)

Fixes #10 